### PR TITLE
Update the festival banner to use the festival settings field_color_text...

### DIFF
--- a/app/festivalBannerView.html
+++ b/app/festivalBannerView.html
@@ -4,7 +4,7 @@
 
     <div class="container">
 
-      <div class="festival-description-container" ng-style="{'background-color':festival.field_color_background, 'color':festival.field_color_text_highlight}">
+      <div class="festival-description-container" ng-style="{'background-color':festival.field_color_text_highlight, 'color':festival.field_color_text}">
         <h2 class="festival-description-home" ng-show="festival.field_description.value" data-ng-bind-html="festival.field_description.value"></h2>
       </div>
 

--- a/app/festivalFooterView.html
+++ b/app/festivalFooterView.html
@@ -2,7 +2,7 @@
 
   <div class="footer-head-container">
     <div class="container footer-head">
-    <div class="footer-festival-sponsor">Supported by<a ui-sref="app.pageSingle({pageAlias: 'bloomberg-supports-wow-women-world-festival-303'})"><img src="/assets/imgs/bloomberg-logo.png" alt="Supported by Bloomberg" /></a></div>
+    <div class="footer-festival-sponsor">Supported by<a ui-sref=""><img src="/assets/imgs/bloomberg-logo.png" alt="Supported by Bloomberg" /></a></div>
       <div class="footer-festival-dates" ng-style="{'color':festival.field_color_highlight}">Festival Dates: {{ festival.field_date_start | amDateFormat:'D' }} &ndash; {{ festival.field_date_end | amDateFormat:'D MMMM YYYY' }}</div>
     </div>
   </div>

--- a/app/festivalNavView.html
+++ b/app/festivalNavView.html
@@ -1,6 +1,6 @@
 <div class="festival-nav-container" data-ng-controller='FestivalNavCtrl'>
 
-  <header class="festival-header" id="navTop" data-ng-controller='FestivalNavCtrl' ng-show="festival">
+  <header class="festival-header" id="navTop" data-ng-controller='FestivalNavCtrl' ng-show="festival" ng-style="{'background-color':festival.field_color_background}">
 
     <div class="container">
 

--- a/assets/sass/_SC-app-festival-banner.scss
+++ b/assets/sass/_SC-app-festival-banner.scss
@@ -26,7 +26,6 @@
         position: absolute;
         z-index: 1;
         top: 10%;
-        background: none !important;
       }
       @include breakpoint($bp-small-desktop) {
         @include span(8);
@@ -35,15 +34,15 @@
         padding: $padding 0;
       }
 
-      .festival-description-home { 
-        a { 
-          color: inherit; 
-          text-decoration: none; 
-          border-bottom: 1px solid; 
+      .festival-description-home {
+        a {
+          color: inherit;
+          text-decoration: none;
+          border-bottom: 1px solid;
           &:hover {
             opacity: 0.5;
           }
-        }    
+        }
       }
 
     }

--- a/release/assets/sass/_SC-app-festival-banner.scss
+++ b/release/assets/sass/_SC-app-festival-banner.scss
@@ -26,7 +26,6 @@
         position: absolute;
         z-index: 1;
         top: 10%;
-        background: none !important;
       }
       @include breakpoint($bp-small-desktop) {
         @include span(8);
@@ -35,15 +34,15 @@
         padding: $padding 0;
       }
 
-      .festival-description-home { 
-        a { 
-          color: inherit; 
-          text-decoration: none; 
-          border-bottom: 1px solid; 
+      .festival-description-home {
+        a {
+          color: inherit;
+          text-decoration: none;
+          border-bottom: 1px solid;
           &:hover {
             opacity: 0.5;
           }
-        }    
+        }
       }
 
     }

--- a/release/festivalBannerView.html
+++ b/release/festivalBannerView.html
@@ -4,7 +4,7 @@
 
     <div class="container">
 
-      <div class="festival-description-container" ng-style="{'background-color':festival.field_color_background, 'color':festival.field_color_text_highlight}">
+      <div class="festival-description-container" ng-style="{'background-color':festival.field_color_text_highlight, 'color':festival.field_color_text}">
         <h2 class="festival-description-home" ng-show="festival.field_description.value" data-ng-bind-html="festival.field_description.value"></h2>
       </div>
 

--- a/release/festivalFooterView.html
+++ b/release/festivalFooterView.html
@@ -2,7 +2,7 @@
 
   <div class="footer-head-container">
     <div class="container footer-head">
-    <div class="footer-festival-sponsor">Supported by<a ui-sref="app.pageSingle({pageAlias: 'bloomberg-supports-wow-women-world-festival-303'})"><img src="/assets/imgs/bloomberg-logo.png" alt="Supported by Bloomberg" /></a></div>
+    <div class="footer-festival-sponsor">Supported by<a ui-sref=""><img src="/assets/imgs/bloomberg-logo.png" alt="Supported by Bloomberg" /></a></div>
       <div class="footer-festival-dates" ng-style="{'color':festival.field_color_highlight}">Festival Dates: {{ festival.field_date_start | amDateFormat:'D' }} &ndash; {{ festival.field_date_end | amDateFormat:'D MMMM YYYY' }}</div>
     </div>
   </div>

--- a/release/festivalNavView.html
+++ b/release/festivalNavView.html
@@ -1,6 +1,6 @@
 <div class="festival-nav-container" data-ng-controller='FestivalNavCtrl'>
 
-  <header class="festival-header" id="navTop" data-ng-controller='FestivalNavCtrl' ng-show="festival">
+  <header class="festival-header" id="navTop" data-ng-controller='FestivalNavCtrl' ng-show="festival" ng-style="{'background-color':festival.field_color_background}">
 
     <div class="container">
 


### PR DESCRIPTION
..._highlight as the header description background colour and field_color_text for text colour.

Remove "background: none !important" from the festival description container applied at the desktop breakpoint.
Add ng-style to the festivalNavView.html so that the header region uses background colours set in the CMS.